### PR TITLE
Fix gradle/gradle#34152

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Below are the key features included in this preview release:
 
 - Fix to [gradle/gradle#29492](https://github.com/gradle/gradle/issues/29492)
 - Fix to [gradle/gradle#29744](https://github.com/gradle/gradle/issues/29744)
+- Fix to [gradle/gradle#34152](https://github.com/gradle/gradle/issues/34152)
 - Support version catalogue dependencies
 - Fix [gradle/gradle-native#994](https://github.com/gradle/gradle-native/issues/994) depends on public header generation
 - Fix gradle/gradle#??? multiple public header directories

--- a/native-companion-plugin.md
+++ b/native-companion-plugin.md
@@ -92,6 +92,7 @@ Here's summary of all features available:
 - _(disabled)_ [**binary-task-extensions**](#feature-binary-task-extensions): Conveniences for configuring binary tasks (i.e. compile task, etc.) without realizing them.
 - _(disabled)_ [**fix-for-gradle-29492**](#feature-fix-for-gradle-29492): Fixes [gradle/gradle#29492](https://github.com/gradle/gradle/issues/29492) regarding inability to track relative path of native compilation units.
 - _(disabled)_ [**fix-for-gradle-29744**](#feature-fix-for-gradle-29744): Fixes [gradle/gradle#29744](https://github.com/gradle/gradle/issues/29744) regarding header dependencies sensitivity to source ordering.
+- _(disabled)_ [**fix-for-gradle-34152**](#feature-fix-for-gradle-34152): Fixes [gradle/gradle#34152](https://github.com/gradle/gradle/issues/34152) regarding incomplete header discovery when encountering header cycle or duplicated headers and macro includes.
 - _(disabled)_ [**fix-for-public-headers**](#feature-fix-for-public-headers): Propagates generated headers' task dependencies and allows multiple public headers.
 - _(disabled)_ [**fix-for-version-catalog**](#feature-fix-for-version-catalog): Accepts version catalog dependencies in native dependency buckets.
 - _(disabled)_ [**incremental-compilation-after-failure**](#feature-incremental-compilation-after-failure): Conserves incremental compilation after compile task failure.
@@ -126,6 +127,11 @@ Essentially, if only a compilation unit's relative path change, core Gradle nati
 Fixes [gradle/gradle#29744](https://github.com/gradle/gradle/issues/29744) regarding header dependencies sensitivity to source ordering.
 The plugin provide an equivalent fix **only** for affected Gradle version.
 The Gradle team fixed the particular issue in Gradle 8.11 and later.
+
+### Feature: fix-for-gradle-34152
+
+Fixes [gradle/gradle#34152](https://github.com/gradle/gradle/issues/34152) regarding incomplete header discovery when encountering header cycle or duplicated headers and macro includes.
+The plugin provide fix for all Gradle version affected.
 
 ### Feature: fix-for-public-headers
 

--- a/native-toolkit.init.gradle
+++ b/native-toolkit.init.gradle
@@ -1,0 +1,390 @@
+/**
+ * This init script serve as a way to debug the compilation state used by the Gradle native core tasks.
+ * The goal is to emulate how Gradle discover the headers (using internal types or a copy of them) (visit mode).
+ * The script also allow access to the compilation state of any compile task (graph mode).
+ */
+import org.gradle.language.nativeplatform.internal.MacroFunction
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.gradle.language.nativeplatform.internal.Expression;
+import org.gradle.language.nativeplatform.internal.IncludeDirectives;
+import org.gradle.language.nativeplatform.internal.Macro;
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.vfs.FileSystemAccess
+import org.gradle.language.nativeplatform.internal.Include
+import org.gradle.language.nativeplatform.internal.IncludeDirectives
+import org.gradle.language.nativeplatform.internal.IncludeType
+import org.gradle.language.nativeplatform.internal.incremental.BuildableCompilationState
+import org.gradle.language.nativeplatform.internal.incremental.CompilationState
+import org.gradle.language.nativeplatform.internal.incremental.DefaultIncrementalCompilation
+import org.gradle.language.nativeplatform.internal.incremental.DefaultSourceIncludesParser
+import org.gradle.language.nativeplatform.internal.incremental.DefaultSourceIncludesResolver
+import org.gradle.language.nativeplatform.internal.incremental.CompilationStateCacheFactory
+import org.gradle.language.nativeplatform.internal.incremental.IncludeFileEdge
+import org.gradle.language.nativeplatform.internal.incremental.IncrementalCompilation
+import org.gradle.language.nativeplatform.internal.incremental.IncrementalCompileSourceProcessor
+import org.gradle.language.nativeplatform.internal.incremental.SourceFileState
+import org.gradle.language.nativeplatform.internal.incremental.SourceIncludesParser
+import org.gradle.language.nativeplatform.internal.incremental.SourceIncludesResolver
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.CSourceParser
+import org.gradle.language.nativeplatform.internal.incremental.CollectingMacroLookup
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.DefaultIncludeDirectives;
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.MacroWithSimpleExpression;
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.RegexBackedCSourceParser;
+
+enum VerificationMode {
+	graph, parse, visit
+}
+
+public class IncrementalCompileFilesFactory {
+	private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalCompileFilesFactory.class);
+	private static final String IGNORE_UNRESOLVED_HEADERS_IN_DEPENDENCIES_PROPERTY_NAME = "org.gradle.internal.native.headers.unresolved.dependencies.ignore";
+	private final IncludeDirectives initialIncludeDirectives;
+	private final SourceIncludesParser sourceIncludesParser;
+	private final SourceIncludesResolver sourceIncludesResolver;
+	private final FileSystemAccess fileSystemAccess;
+	private final boolean ignoreUnresolvedHeadersInDependencies;
+
+	public IncrementalCompileFilesFactory(IncludeDirectives initialIncludeDirectives, SourceIncludesParser sourceIncludesParser, SourceIncludesResolver sourceIncludesResolver, FileSystemAccess fileSystemAccess) {
+		this.initialIncludeDirectives = initialIncludeDirectives;
+		this.sourceIncludesParser = sourceIncludesParser;
+		this.sourceIncludesResolver = sourceIncludesResolver;
+		this.fileSystemAccess = fileSystemAccess;
+		this.ignoreUnresolvedHeadersInDependencies = Boolean.getBoolean(IGNORE_UNRESOLVED_HEADERS_IN_DEPENDENCIES_PROPERTY_NAME);
+	}
+
+		private final Set<File> existingHeaders = new HashSet();
+		private final Map<File, FileDetails> visitedFiles = new HashMap();
+		private boolean hasUnresolvedHeaders;
+
+		FileVisitResult visitSourceFile(File sourceFile) {
+			return (FileVisitResult) fileSystemAccess.readRegularFileContentHash(sourceFile.getAbsolutePath()).map((fileContent) -> {
+					CollectingMacroLookup visibleMacros = new CollectingMacroLookup(initialIncludeDirectives);
+					FileVisitResult result = this.visitFile(sourceFile, fileContent, visibleMacros, new HashSet(), this.existingHeaders);
+					Set<IncludeFileEdge> includedFiles = new LinkedHashSet();
+					result.collectFilesInto(includedFiles, new HashSet());
+					if (/*newState.isHasUnresolved()*/result.result == IncludeFileResolutionResult.UnresolvedMacroIncludes) {
+						this.hasUnresolvedHeaders = true;
+					}
+
+					return result;
+			}).orElse(null);
+		}
+
+		private FileVisitResult visitFile(File file, HashCode newHash, CollectingMacroLookup visibleMacros, Set<HashCode> visited, Set<File> existingHeaders) {
+			FileDetails fileDetails = (FileDetails)this.visitedFiles.get(file);
+			if (fileDetails != null && fileDetails.results != null) {
+				fileDetails.results.collectInto(visibleMacros)
+				return fileDetails.results;
+			} else if (!visited.add(newHash)) {
+				return new FileVisitResult(file);
+			} else {
+				if (fileDetails == null) {
+					IncludeDirectives includeDirectives = sourceIncludesParser.parseIncludes(file);
+					fileDetails = new FileDetails(includeDirectives);
+					this.visitedFiles.put(file, fileDetails);
+				}
+
+				CollectingMacroLookup includedFileDirectives = new CollectingMacroLookup();
+				visibleMacros.append(file, fileDetails.directives);
+				List<Include> allIncludes = fileDetails.directives.getAll();
+				List<FileVisitResult> included = (List<FileVisitResult>)(allIncludes.isEmpty() ? Collections.emptyList() : new ArrayList(allIncludes.size()));
+				List<IncludeFileEdge> edges = (List<IncludeFileEdge>)(allIncludes.isEmpty() ? Collections.emptyList() : new ArrayList(allIncludes.size()));
+				IncludeFileResolutionResult result = IncludeFileResolutionResult.NoMacroIncludes;
+
+				for(Include include : allIncludes) {
+					if (include.getType() == IncludeType.MACRO && result == IncludeFileResolutionResult.NoMacroIncludes) {
+						result = IncludeFileResolutionResult.HasMacroIncludes;
+					}
+
+					SourceIncludesResolver.IncludeResolutionResult resolutionResult = sourceIncludesResolver.resolveInclude(file, include, visibleMacros);
+					if (!resolutionResult.isComplete()) {
+						LOGGER.info("Cannot locate header file for '{}' in source file '{}'. Assuming changed.", include.getAsSourceText(), file.getName());
+						if (!ignoreUnresolvedHeadersInDependencies) {
+							result = IncludeFileResolutionResult.UnresolvedMacroIncludes;
+						}
+					}
+
+					for(SourceIncludesResolver.IncludeFile includeFile : resolutionResult.getFiles()) {
+						existingHeaders.add(includeFile.getFile());
+						FileVisitResult includeVisitResult = this.visitFile(includeFile.getFile(), includeFile.getContentHash(), visibleMacros, visited, existingHeaders);
+						if (includeVisitResult.result.ordinal() > result.ordinal()) {
+							result = includeVisitResult.result;
+						}
+
+						includeVisitResult.collectDependencies(includedFileDirectives);
+						included.add(includeVisitResult);
+						edges.add(new IncludeFileEdge(includeFile.getPath(), includeFile.isQuotedInclude() ? newHash : null, includeFile.getContentHash()));
+					}
+				}
+
+				FileVisitResult visitResult = new FileVisitResult(file, result, fileDetails.directives, included, edges, includedFileDirectives);
+				if (result == IncludeFileResolutionResult.NoMacroIncludes) {
+					fileDetails.results = visitResult;
+				}
+
+				return visitResult;
+			}
+		}
+
+	private static enum IncludeFileResolutionResult {
+		NoMacroIncludes,
+		HasMacroIncludes,
+		UnresolvedMacroIncludes;
+	}
+
+	private static class FileDetails {
+		final IncludeDirectives directives;
+//		@Nullable
+		FileVisitResult results;
+
+		FileDetails(IncludeDirectives directives) {
+			this.directives = directives;
+		}
+	}
+
+	private static class FileVisitResult {
+		private final File file;
+		private final IncludeFileResolutionResult result;
+		private final IncludeDirectives includeDirectives;
+		private final List<FileVisitResult> included;
+		private final List<IncludeFileEdge> edges;
+		private final CollectingMacroLookup includeFileDirectives;
+
+		FileVisitResult(File file, IncludeFileResolutionResult result, IncludeDirectives includeDirectives, List<FileVisitResult> included, List<IncludeFileEdge> edges, CollectingMacroLookup dependentIncludeDirectives) {
+			this.file = file;
+			this.result = result;
+			this.includeDirectives = includeDirectives;
+			this.included = included;
+			this.edges = edges;
+			this.includeFileDirectives = dependentIncludeDirectives;
+		}
+
+		FileVisitResult(File file) {
+			this.file = file;
+			this.result = IncludeFileResolutionResult.NoMacroIncludes;
+			this.includeDirectives = null;
+			this.included = Collections.emptyList();
+			this.edges = Collections.emptyList();
+			this.includeFileDirectives = null;
+		}
+
+		void collectDependencies(CollectingMacroLookup directives) {
+			if (this.includeDirectives != null) {
+				this.collectInto(directives)
+			}
+
+		}
+
+		void collectFilesInto(Collection<IncludeFileEdge> files, Set<File> seen) {
+			if (this.includeDirectives != null && seen.add(this.file)) {
+				files.addAll(this.edges);
+
+				for(FileVisitResult include : this.included) {
+					include.collectFilesInto(files, seen);
+				}
+			}
+
+		}
+
+		public void collectInto(CollectingMacroLookup lookup) {
+			if (this.includeDirectives != null) {
+				lookup.append(this.file, this.includeDirectives);
+				this.includeFileDirectives.appendTo(lookup);
+			}
+
+		}
+	}
+}
+
+abstract class VerificationTask extends DefaultTask {
+	private static final CollectingMacroLookup EMPTY = new CollectingMacroLookup()
+	@Inject protected abstract CompilationStateCacheFactory getCompilationStateCacheFactory()
+	@Inject protected abstract CSourceParser getCSourceParser()
+	@Inject protected abstract FileSystemAccess getFileSystemAccess()
+	@Inject protected abstract ProviderFactory getProviders()
+	private final Provider<AbstractNativeCompileTask> compileTask = taskPath.map { toCompileTask(it) }
+	private final Provider<File> singleFile = singleFilePath.map(File::new)
+
+	VerificationTask() {
+		taskPath.convention(providers.systemProperty("task-path"))
+		verificationMode.convention(providers.systemProperty("mode").map(VerificationMode::valueOf))
+		ignores.convention(providers.systemProperty("ignores"))
+		singleFilePath.convention(providers.systemProperty("single-file"))
+	}
+
+	@Internal
+	@Option(option = "task-path", description = "task path to use")
+	abstract Property<String> getTaskPath();
+
+	protected AbstractNativeCompileTask toCompileTask(String taskPath) {
+		def result = (AbstractNativeCompileTask) project.tasks.findByPath(taskPath)
+		if (result == null) {
+			result = (AbstractNativeCompileTask) project.tasks.findByPath(":${taskPath.split(':').drop(2).join(':')}")
+		}
+		return result
+	}
+
+	@Internal
+	@Option(option = "mode", description = "mode of verification")
+	abstract Property<VerificationMode> getVerificationMode();
+
+	@Internal
+	@Option(option = 'single-file', description = 'result for this single file')
+	abstract Property<String> getSingleFilePath()
+
+	@Internal
+	@Option(option = 'ignores', description = 'things to ignore')
+	abstract Property<String> getIgnores()
+
+	@TaskAction
+	void doVerification() {
+		switch (verificationMode.get()) {
+			case VerificationMode.graph: doPrintGraph(); break;
+			case VerificationMode.parse: doParseFile(); break;
+			case VerificationMode.visit: doVisitFile(); break;
+		}
+	}
+
+	private void doParseFile() {
+		def parser = new DefaultSourceIncludesParser(getCSourceParser(), false)
+		def directives = parser.parseIncludes(singleFile.get())
+		def allIncludePaths = compileTask.map { new ArrayList<>(it.includes.files) }.orNull
+		if (!ignores.getOrElse('').contains('do-not-resolve') && allIncludePaths == null) return
+
+		for (def include : directives.includesOnly) {
+			println(include.asSourceText)
+			if (!ignores.getOrElse('').contains('do-not-resolve')) {
+				def depParser = new DefaultSourceIncludesResolver(allIncludePaths, fileSystemAccess)
+				def result = depParser.resolveInclude(singleFile.get(), include, new CollectingMacroLookup())
+				if (result.complete) {
+					result.files.each { details ->
+						println(" -> ${details.file}")
+					}
+				}
+			}
+		}
+	}
+
+	private void doVisitFile() {
+		def task = compileTask.orNull
+		if (task == null) return
+
+		def macros = task.macros
+		def allIncludePaths = new ArrayList<>(task.includes.plus(task.systemIncludes).files)
+		def source = new TreeSet<>(task.source.files)
+
+		IncludeDirectives includeDirectives = this.directivesForMacros(macros);
+		def incrementalCompileSourceProcessor = new IncrementalCompileFilesFactory(includeDirectives, new DefaultSourceIncludesParser(getCSourceParser(), false), new DefaultSourceIncludesResolver(allIncludePaths, fileSystemAccess), fileSystemAccess)
+		for (def sourceFile in source) {
+			println("=> $sourceFile")
+			def result = incrementalCompileSourceProcessor.visitSourceFile(sourceFile)
+			Set<IncludeFileEdge> edges = new LinkedHashSet();
+			result.collectFilesInto(edges, new HashSet());
+			edges.each { edge ->
+				if (ignores.getOrElse('').contains('system-includes') && edge.includedBy == null) return
+				println(" -> ${edge.includePath} [${edge.includedBy} => ${edge.resolvedTo}]")
+			}
+		}
+	}
+
+	private IncludeDirectives directivesForMacros(Map<String, String> macros) {
+		List<Macro> builder = new ArrayList<>();
+
+		for(Map.Entry<String, String> entry : macros.entrySet()) {
+			Expression expression = RegexBackedCSourceParser.parseExpression((String)entry.getValue());
+			builder.add(new MacroWithSimpleExpression((String)entry.getKey(), expression.getType(), expression.getValue()));
+		}
+
+		return new IncludeDirectives() {
+			private final List<Macro> values = builder;
+
+			@Override
+			List<Include> getQuotedIncludes() {
+				return []
+			}
+
+			@Override
+			List<Include> getSystemIncludes() {
+				return []
+			}
+
+			@Override
+			List<Include> getMacroIncludes() {
+				return []
+			}
+
+			@Override
+			List<Include> getAll() {
+				return []
+			}
+
+			@Override
+			List<Include> getIncludesOnly() {
+				return []
+			}
+
+			@Override
+			Iterable<Macro> getMacros(String name) {
+				return values.findAll { it.name == name }
+			}
+
+			@Override
+			Iterable<MacroFunction> getMacroFunctions(String name) {
+				return []
+			}
+
+			@Override
+			Collection<Macro> getAllMacros() {
+				return values
+			}
+
+			@Override
+			Collection<MacroFunction> getAllMacroFunctions() {
+				return []
+			}
+
+			@Override
+			boolean hasMacros() {
+				return true
+			}
+
+			@Override
+			boolean hasMacroFunctions() {
+				return false
+			}
+
+			@Override
+			IncludeDirectives discardImports() {
+				return this
+			}
+		}
+	}
+
+	private void doPrintGraph() {
+		def taskPath = compileTask.map { it.path }.orNull
+		if (taskPath == null) return
+
+		def state = compilationStateCacheFactory.create(taskPath).get()
+		def singleFile = singleFile.orNull
+		state.sourceInputs.each { sourceInput ->
+			if (singleFile == null || sourceInput == singleFile) {
+				def sourceState = state.getState(sourceInput)
+				println("==> ${sourceInput.absolutePath} [${sourceState.hash}] ${sourceState.isHasUnresolved() ? '(U)' : ''}")
+				sourceState.edges.each { edge ->
+					if (ignores.getOrElse('').contains('system-includes') && edge.includedBy == null) return
+					println(" -> ${edge.includePath} [${edge.includedBy} => ${edge.resolvedTo}]")
+				}
+			}
+		}
+	}
+}
+
+// Inject in all builds
+beforeSettings {
+	rootProject {
+		tasks.register('verify', VerificationTask) {
+			dependsOn(gradle.includedBuilds.collect { it.task(path) })
+		}
+	}
+}

--- a/src/functionalTest/java/dev/nokee/companion/AbstractNativeLanguageHeaderDiscoveryFunctionalTester.java
+++ b/src/functionalTest/java/dev/nokee/companion/AbstractNativeLanguageHeaderDiscoveryFunctionalTester.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 
 import static dev.gradleplugins.runnerkit.GradleExecutor.gradleTestKit;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @ExtendWith({GradleProjectExtension.class, GradleTaskUnderTestExtension.class})
@@ -27,7 +28,7 @@ public interface AbstractNativeLanguageHeaderDiscoveryFunctionalTester {
 	@Test
 	default void canDiscoverHeaderFromDefinedMacros(TaskUnderTest taskUnderTest, @TempDir Path testDirectory, @GradleProject("project-with-include-macros") GradleBuildElement project) throws IOException {
 		GradleBuildElement build = project.writeToDirectory(testDirectory);
-		GradleRunner runner = GradleRunner.create(gradleTestKit()).inDirectory(build.getLocation()).withPluginClasspath().forwardOutput();
+		GradleRunner runner = GradleRunner.create(gradleTestKit()).inDirectory(build.getLocation()).withPluginClasspath().forwardOutput().withArgument("-i");
 		BuildResult result = null;
 
 		result = runner.withTasks(taskUnderTest.toString()).build();
@@ -40,5 +41,6 @@ public interface AbstractNativeLanguageHeaderDiscoveryFunctionalTester {
 		assertThat(result.task(taskUnderTest.toString()).getOutcome(), equalTo(TaskOutcome.SUCCESS));
 
 		// TODO: Assert incremental, not full rebuild
+		assertThat(result.task(taskUnderTest.toString()).getOutput(), containsString("Found all include files for ':compile'"));
 	}
 }

--- a/src/functionalTest/java/dev/nokee/companion/AbstractNativeLanguageHeaderDiscoveryFunctionalTester.java
+++ b/src/functionalTest/java/dev/nokee/companion/AbstractNativeLanguageHeaderDiscoveryFunctionalTester.java
@@ -84,4 +84,25 @@ public interface AbstractNativeLanguageHeaderDiscoveryFunctionalTester {
 		assertThat(result.task(taskUnderTest.toString()).getOutput(), containsString("/src/main/cpp/b.cpp"));
 		assertThat(result.task(taskUnderTest.toString()).getOutput(), not(containsString("/src/main/cpp/c.cpp")));
 	}
+
+	@Test
+	default void discoverConsistentHeaderGraphOnMacroIncludeWithDuplicatedHeadersHavingDifferentResolvingPath(TaskUnderTest taskUnderTest, @TempDir Path testDirectory, @GradleProject("project-for-gradle-34152-ex2") GradleBuildElement project) throws IOException {
+		GradleBuildElement build = project.writeToDirectory(testDirectory);
+		GradleRunner runner = GradleRunner.create(gradleTestKit()).inDirectory(build.getLocation()).withPluginClasspath().forwardOutput().withArgument("-i");
+		BuildResult result = null;
+
+		result = runner.withTasks(taskUnderTest.toString()).build();
+		result = runner.withTasks(taskUnderTest.toString()).build();
+		assertThat(result.task(taskUnderTest.toString()).getOutcome(), equalTo(TaskOutcome.UP_TO_DATE));
+
+		Files.write(build.file("src/main/headers/f.h"), Arrays.asList("", "// some new lines", ""), StandardOpenOption.APPEND);
+
+		result = runner.withTasks(taskUnderTest.toString()).build();
+		assertThat(result.task(taskUnderTest.toString()).getOutcome(), equalTo(TaskOutcome.SUCCESS));
+
+		// TODO: Assert incremental, not full rebuild
+		assertThat(result.task(taskUnderTest.toString()).getOutput(), containsString("/src/main/cpp/a.cpp"));
+		assertThat(result.task(taskUnderTest.toString()).getOutput(), containsString("/src/main/cpp/b.cpp"));
+		assertThat(result.task(taskUnderTest.toString()).getOutput(), not(containsString("/src/main/cpp/c.cpp")));
+	}
 }

--- a/src/functionalTest/java/dev/nokee/companion/CppCompileTaskFunctionalTests.java
+++ b/src/functionalTest/java/dev/nokee/companion/CppCompileTaskFunctionalTests.java
@@ -373,4 +373,76 @@ class CppCompileTaskFunctionalTests implements AbstractNativeLanguageCompilation
 
 		return build;
 	}
+
+	@GradleProject("project-for-gradle-34152-ex2")
+	public static GradleBuildElement makeProjectForGradle34152Ex2() throws IOException {
+		GradleBuildElement build = makeEmptyProject();
+		Files.write(build.file("src/main/cpp/a.cpp"), Arrays.asList(
+			"#include \"a.h\"",
+			"#include \"b.h\""
+		));
+		Files.write(build.file("src/main/cpp/b.cpp"), Arrays.asList(
+			"#include \"b.h\""
+		));
+		Files.write(build.file("src/main/cpp/c.cpp"), Arrays.asList(
+			"int main() { return 0; }"
+		));
+
+		Files.write(build.file("src/main/headers/a.h"), Arrays.asList(
+			"// a.h and copied-a.h have exact same content on purpose",
+			"#ifndef A_H_",
+			"#define A_H_",
+			"#include \"c.h\"",
+			"int a() { return 1; }",
+			"#endif"
+		));
+		Files.write(build.file("src/main/headers/b.h"), Arrays.asList(
+			"#pragma once",
+			"#include \"dir/a.h\"",
+			"int b() { return 2; }"
+		));
+		Files.write(build.file("src/main/headers/dir/a.h"), Arrays.asList(
+			"// a.h and dir/a.h have exact same content on purpose",
+			"#ifndef A_H_",
+			"#define A_H_",
+			"#include \"c.h\"",
+			"int a() { return 1; }",
+			"#endif"
+		));
+		Files.write(build.file("src/main/headers/dir/c.h"), Arrays.asList(
+			"#pragma once",
+			"#include \"f.h\"",
+			"int c2() { return 3; }"
+		));
+		Files.write(build.file("src/main/headers/c.h"), Arrays.asList(
+			"#pragma once",
+			"#include \"d.h\"",
+			"#include MY_MACRO_INCLUDE",
+			"int c() { return 3; }"
+		));
+		Files.write(build.file("src/main/headers/d.h"), Arrays.asList(
+			"#pragma once",
+			"// modifying will only recompile `a.cpp`, not `b.cpp`",
+			"int d() { return 4; }"
+		));
+		Files.write(build.file("src/main/headers/e.h"), Arrays.asList(
+			"#pragma once",
+			"// macro include file, will also be hidden from `b.cpp`",
+			"int e() { return 5; }"
+		));
+		Files.write(build.file("src/main/headers/f.h"), Arrays.asList(
+			"#pragma once",
+			"int f() { return 6; }"
+		));
+
+		build.getBuildFile().append(groovyDsl("""
+			subject.configure {
+				source(files('src/main/cpp').asFileTree)
+				includes.from('src/main/headers')
+				options.preprocessorOptions.define('MY_MACRO_INCLUDE', '"e.h"')
+			}
+		"""));
+
+		return build;
+	}
 }

--- a/src/main/java/dev/nokee/companion/LegacySupportPlugin.java
+++ b/src/main/java/dev/nokee/companion/LegacySupportPlugin.java
@@ -45,6 +45,7 @@ import javax.inject.Inject;
 
 		feature.apply("fix-for-gradle-29492");
 		feature.apply("fix-for-gradle-29744");
+		feature.apply("fix-for-gradle-34152");
 		feature.apply("fix-for-public-headers");
 		feature.apply("fix-for-version-catalog");
 		feature.apply("incremental-compilation-after-failure");

--- a/src/main/java/dev/nokee/companion/features/CppCompileTask.java
+++ b/src/main/java/dev/nokee/companion/features/CppCompileTask.java
@@ -54,6 +54,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -569,6 +570,8 @@ import static dev.nokee.companion.features.TransactionalCompiler.outputFileDir;
 		this.executor = executor;
 		this.source = super.getSource();
 
+		replaceMacrosField(getMacros());
+
 		getBundles().set(providers.provider(() -> {
 			if (this.allOptions == null) {
 				return Collections.emptyList(); // bailout quickly
@@ -623,6 +626,11 @@ import static dev.nokee.companion.features.TransactionalCompiler.outputFileDir;
 				return allOptions.forAllSources(getSource().getAsFileTree()).map(OptionsIter::unrolled);
 			}
 		};
+	}
+
+	private void replaceMacrosField(Map<String, String> lazyMacros) {
+		Field AbstractNativeCompileTask__macros = getField(AbstractNativeCompileTask.class, "macros");
+		updateFieldValue(AbstractNativeCompileTask__macros, this, lazyMacros);
 	}
 
 	@Override

--- a/src/main/java/dev/nokee/companion/features/DefaultIncrementalCompilerBuilder.java
+++ b/src/main/java/dev/nokee/companion/features/DefaultIncrementalCompilerBuilder.java
@@ -36,6 +36,8 @@ import org.gradle.language.nativeplatform.internal.incremental.sourceparser.Rege
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -153,7 +155,18 @@ class DefaultIncrementalCompilerBuilder implements IncrementalCompilerBuilder {
 
 			incrementalCompilation = incrementalCompileProcessor.processSourceFiles(new TreeSet<>(sourceFiles.getFiles()));
 			DefaultHeaderDependenciesCollector headerDependenciesCollector = new DefaultHeaderDependenciesCollector(directoryFileTreeFactory);
-			return headerDependenciesCollector.collectExistingHeaderDependencies(taskPath, includeRoots, incrementalCompilation);
+			return collectExistingHeaderDependencies(headerDependenciesCollector, taskPath, includeRoots, incrementalCompilation);
+		}
+
+		private static Set<File> collectExistingHeaderDependencies(HeaderDependenciesCollector self, String taskPath, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
+			try {
+				Method HeaderDependenciesCollector__collectExistingHeaderDependencies = HeaderDependenciesCollector.class.getMethod("collectExistingHeaderDependencies", String.class, List.class, IncrementalCompilation.class);
+				@SuppressWarnings("unchecked")
+				Set<File> result = (Set<File>) HeaderDependenciesCollector__collectExistingHeaderDependencies.invoke(self, taskPath, includeRoots, incrementalCompilation);
+				return result;
+			} catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
 		}
 
 		private IncludeDirectives directivesForMacros(Map<String, String> macros) {

--- a/src/main/java/dev/nokee/companion/features/DefaultIncrementalCompilerBuilder.java
+++ b/src/main/java/dev/nokee/companion/features/DefaultIncrementalCompilerBuilder.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.companion.features;
+
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskOutputsInternal;
+import org.gradle.api.internal.file.TaskFileVarFactory;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.file.collections.MinimalFileSet;
+import org.gradle.api.internal.tasks.properties.LifecycleAwareValue;
+import org.gradle.api.provider.Provider;
+import org.gradle.cache.ObjectHolder;
+import org.gradle.internal.file.Deleter;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.vfs.FileSystemAccess;
+import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.language.nativeplatform.internal.*;
+import org.gradle.language.nativeplatform.internal.incremental.*;
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.CSourceParser;
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.MacroWithSimpleExpression;
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.RegexBackedCSourceParser;
+import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+
+class DefaultIncrementalCompilerBuilder implements IncrementalCompilerBuilder {
+	private final BuildOperationRunner buildOperationRunner;
+	private final CompilationStateCacheFactory compilationStateCacheFactory;
+	private final CSourceParser sourceParser;
+	private final Deleter deleter;
+	private final DirectoryFileTreeFactory directoryFileTreeFactory;
+	private final FileSystemAccess fileSystemAccess;
+	private final TaskFileVarFactory fileVarFactory;
+
+	public DefaultIncrementalCompilerBuilder(
+		BuildOperationRunner buildOperationRunner,
+		CompilationStateCacheFactory compilationStateCacheFactory,
+		CSourceParser sourceParser,
+		Deleter deleter,
+		DirectoryFileTreeFactory directoryFileTreeFactory,
+		FileSystemAccess fileSystemAccess,
+		TaskFileVarFactory fileVarFactory
+	) {
+		this.buildOperationRunner = buildOperationRunner;
+		this.compilationStateCacheFactory = compilationStateCacheFactory;
+		this.deleter = deleter;
+		this.directoryFileTreeFactory = directoryFileTreeFactory;
+		this.fileSystemAccess = fileSystemAccess;
+		this.fileVarFactory = fileVarFactory;
+		this.sourceParser = sourceParser;
+	}
+
+	@Override
+	public IncrementalCompiler newCompiler(TaskInternal task, FileCollection sourceFiles, FileCollection includeDirs, Map<String, String> macros, Provider<Boolean> importAware) {
+		return new StateCollectingIncrementalCompiler(
+			task,
+			includeDirs,
+			sourceFiles,
+			macros,
+			importAware,
+			buildOperationRunner,
+			compilationStateCacheFactory,
+			sourceParser,
+			deleter,
+			directoryFileTreeFactory,
+			fileSystemAccess,
+			fileVarFactory
+		);
+	}
+
+	private static class StateCollectingIncrementalCompiler implements IncrementalCompiler, MinimalFileSet, LifecycleAwareValue {
+		private final BuildOperationRunner buildOperationRunner;
+		private final CompilationStateCacheFactory compilationStateCacheFactory;
+		private final CSourceParser sourceParser;
+		private final Deleter deleter;
+		private final DirectoryFileTreeFactory directoryFileTreeFactory;
+		private final FileSystemAccess fileSystemAccess;
+
+		private final Map<String, String> macros;
+		private final Provider<Boolean> importAware;
+		private final TaskOutputsInternal taskOutputs;
+		private final FileCollection includeDirs;
+		private final String taskPath;
+		private final FileCollection sourceFiles;
+		private final FileCollection headerFilesCollection;
+		private ObjectHolder<CompilationState> compileStateCache;
+		private IncrementalCompilation incrementalCompilation;
+
+		StateCollectingIncrementalCompiler(
+			TaskInternal task,
+			FileCollection includeDirs,
+			FileCollection sourceFiles,
+			Map<String, String> macros,
+			Provider<Boolean> importAware,
+
+			BuildOperationRunner buildOperationRunner,
+			CompilationStateCacheFactory compilationStateCacheFactory,
+			CSourceParser sourceParser,
+			Deleter deleter,
+			DirectoryFileTreeFactory directoryFileTreeFactory,
+			FileSystemAccess fileSystemAccess,
+			TaskFileVarFactory fileVarFactory
+		) {
+			this.taskOutputs = task.getOutputs();
+			this.taskPath = task.getPath();
+			this.includeDirs = includeDirs;
+			this.sourceFiles = sourceFiles;
+			this.macros = macros;
+			this.importAware = importAware;
+			this.headerFilesCollection = fileVarFactory.newCalculatedInputFileCollection(task, this, sourceFiles, includeDirs);
+
+			this.buildOperationRunner = buildOperationRunner;
+			this.compilationStateCacheFactory = compilationStateCacheFactory;
+			this.deleter = deleter;
+			this.directoryFileTreeFactory = directoryFileTreeFactory;
+			this.fileSystemAccess = fileSystemAccess;
+			this.sourceParser = sourceParser;
+		}
+
+		@Override
+		public <T extends NativeCompileSpec> Compiler<T> createCompiler(Compiler<T> compiler) {
+			if (incrementalCompilation == null) {
+				throw new IllegalStateException("Header files should be calculated before compiler is created.");
+			}
+			return new IncrementalNativeCompiler<T>(taskOutputs, compiler, deleter, compileStateCache, incrementalCompilation);
+		}
+
+		@Override
+		public Set<File> getFiles() {
+			List<File> includeRoots = new ArrayList<>(includeDirs.getFiles());
+			compileStateCache = compilationStateCacheFactory.create(taskPath);
+			DefaultSourceIncludesParser sourceIncludesParser = new DefaultSourceIncludesParser(sourceParser, importAware.get());
+			DefaultSourceIncludesResolver dependencyParser = new DefaultSourceIncludesResolver(includeRoots, fileSystemAccess);
+			IncludeDirectives includeDirectives = directivesForMacros(macros);
+			IncrementalCompileFilesFactory incrementalCompileFilesFactory = new IncrementalCompileFilesFactory(includeDirectives, sourceIncludesParser, dependencyParser, fileSystemAccess);
+			IncrementalCompileProcessor incrementalCompileProcessor = new IncrementalCompileProcessor(compileStateCache, incrementalCompileFilesFactory, buildOperationRunner);
+
+			incrementalCompilation = incrementalCompileProcessor.processSourceFiles(new TreeSet<>(sourceFiles.getFiles()));
+			DefaultHeaderDependenciesCollector headerDependenciesCollector = new DefaultHeaderDependenciesCollector(directoryFileTreeFactory);
+			return headerDependenciesCollector.collectExistingHeaderDependencies(taskPath, includeRoots, incrementalCompilation);
+		}
+
+		private IncludeDirectives directivesForMacros(Map<String, String> macros) {
+			List<Macro> values = new ArrayList<>();
+			for(Map.Entry<String, String> entry : macros.entrySet()) {
+				Expression expression = RegexBackedCSourceParser.parseExpression(entry.getValue());
+				values.add(new MacroWithSimpleExpression(entry.getKey(), expression.getType(), expression.getValue()));
+			}
+			return new IncludeDirectives() {
+				@Override
+				public List<Include> getQuotedIncludes() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<Include> getSystemIncludes() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<Include> getMacroIncludes() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<Include> getAll() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<Include> getIncludesOnly() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public Iterable<Macro> getMacros(String name) {
+					return values.stream().filter(it -> it.getName().equals(name)).collect(Collectors.toList());
+				}
+
+				@Override
+				public Iterable<MacroFunction> getMacroFunctions(String name) {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public Collection<Macro> getAllMacros() {
+					return values;
+				}
+
+				@Override
+				public Collection<MacroFunction> getAllMacroFunctions() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public boolean hasMacros() {
+					return !values.isEmpty();
+				}
+
+				@Override
+				public boolean hasMacroFunctions() {
+					return false; // only simple macros
+				}
+
+				@Override
+				public IncludeDirectives discardImports() {
+					return this; // no includes
+				}
+			};
+		}
+
+		@Override
+		public void prepareValue() {
+		}
+
+		@Override
+		public void cleanupValue() {
+			compileStateCache = null;
+			incrementalCompilation = null;
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "header files for " + taskPath;
+		}
+
+		@Override
+		public FileCollection getHeaderFiles() {
+			return headerFilesCollection;
+		}
+	}
+}

--- a/src/main/java/dev/nokee/companion/features/FixHeaderDiscoveryCachingFeature.java
+++ b/src/main/java/dev/nokee/companion/features/FixHeaderDiscoveryCachingFeature.java
@@ -1,0 +1,57 @@
+package dev.nokee.companion.features;
+
+import dev.nokee.language.cpp.tasks.CppCompile;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.internal.file.TaskFileVarFactory;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.internal.file.Deleter;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.vfs.FileSystemAccess;
+import org.gradle.language.nativeplatform.internal.incremental.CompilationStateCacheFactory;
+import org.gradle.language.nativeplatform.internal.incremental.IncrementalCompilerBuilder;
+import org.gradle.language.nativeplatform.internal.incremental.sourceparser.CSourceParser;
+
+import javax.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+abstract class FixHeaderDiscoveryCachingFeature implements Plugin<Project> {
+	private final TaskContainer tasks;
+
+	@Inject
+	public FixHeaderDiscoveryCachingFeature(TaskContainer tasks) {
+		this.tasks = tasks;
+	}
+
+	//region Services required by IncrementalCompilerBuilder
+	@Inject protected abstract BuildOperationRunner getBuildOperationRunner();
+	@Inject protected abstract CompilationStateCacheFactory getCompilationStateCacheFactory();
+	@Inject protected abstract CSourceParser getSourceParser();
+	@Inject protected abstract Deleter getDeleter();
+	@Inject protected abstract DirectoryFileTreeFactory getDirectoryFileTreeFactory();
+	@Inject protected abstract FileSystemAccess getFileSystemAccess();
+	@Inject protected abstract TaskFileVarFactory getFileVarFactory();
+	//endregion
+
+	@Override
+	public void apply(Project project) {
+		tasks.withType(CppCompile.class).configureEach(task -> {
+			incrementalCompilerBuilderOf(task).set(new DefaultIncrementalCompilerBuilder(getBuildOperationRunner(), getCompilationStateCacheFactory(), getSourceParser(), getDeleter(), getDirectoryFileTreeFactory(), getFileSystemAccess(), getFileVarFactory()));
+		});
+	}
+
+	private static Property<IncrementalCompilerBuilder> incrementalCompilerBuilderOf(CppCompile task) {
+		try {
+			final Method CppCompile__getIncrementalCompilerBuilderService = task.getClass().getMethod("getIncrementalCompilerBuilderService");
+
+			@SuppressWarnings("unchecked")
+			final Property<IncrementalCompilerBuilder> result = (Property<IncrementalCompilerBuilder>) CppCompile__getIncrementalCompilerBuilderService.invoke(task);
+			return result;
+		} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/dev/nokee/companion/features/IncrementalCompileFilesFactory.java
+++ b/src/main/java/dev/nokee/companion/features/IncrementalCompileFilesFactory.java
@@ -124,16 +124,16 @@ class IncrementalCompileFilesFactory {
 				// Source file has changed
 				return false;
 			}
-			if (previousState.getEdges().isEmpty()) {
+			if (edgesOf(previousState).isEmpty()) {
 				// Source file has not changed and no include files
 				return true;
 			}
 
 			// Check each unique edge in the include file graph
-			Map<HashCode, File> includes = new HashMap<HashCode, File>(previousState.getEdges().size());
+			Map<HashCode, File> includes = new HashMap<HashCode, File>(edgesOf(previousState).size());
 			Set<File> headers = new HashSet<File>();
 			includes.put(fileHash, sourceFile);
-			for (IncludeFileEdge includeFileEdge : previousState.getEdges()) {
+			for (IncludeFileEdge includeFileEdge : edgesOf(previousState)) {
 				File includedFrom = includeFileEdge.getIncludedBy() != null ? includes.get(includeFileEdge.getIncludedBy()) : null;
 				SourceIncludesResolver.IncludeFile includeFile = sourceIncludesResolver.resolveInclude(includedFrom, includeFileEdge.getIncludePath());
 				if (includeFile == null) {
@@ -309,6 +309,18 @@ class IncrementalCompileFilesFactory {
 
 			return SourceFileState__new.newInstance(hash, hasUnresolved, resolvedIncludes_asImmutableSet);
 		} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static Set<IncludeFileEdge> edgesOf(SourceFileState self) {
+		try {
+			Method SourceFileState__getEdges = SourceFileState.class.getMethod("getEdges");
+
+			@SuppressWarnings("unchecked")
+			Set<IncludeFileEdge> result = (Set<IncludeFileEdge>) SourceFileState__getEdges.invoke(self);
+			return result;
+		} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/dev/nokee/companion/features/IncrementalCompileFilesFactory.java
+++ b/src/main/java/dev/nokee/companion/features/IncrementalCompileFilesFactory.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.nokee.companion.features;
+
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.vfs.FileSystemAccess;
+import org.gradle.language.nativeplatform.internal.Include;
+import org.gradle.language.nativeplatform.internal.IncludeDirectives;
+import org.gradle.language.nativeplatform.internal.IncludeType;
+import org.gradle.language.nativeplatform.internal.incremental.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+
+class IncrementalCompileFilesFactory {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalCompileFilesFactory.class);
+	private static final String IGNORE_UNRESOLVED_HEADERS_IN_DEPENDENCIES_PROPERTY_NAME = "org.gradle.internal.native.headers.unresolved.dependencies.ignore";
+
+	private final IncludeDirectives initialIncludeDirectives;
+	private final SourceIncludesParser sourceIncludesParser;
+	private final SourceIncludesResolver sourceIncludesResolver;
+	private final FileSystemAccess fileSystemAccess;
+	private final boolean ignoreUnresolvedHeadersInDependencies;
+
+	public IncrementalCompileFilesFactory(IncludeDirectives initialIncludeDirectives, SourceIncludesParser sourceIncludesParser, SourceIncludesResolver sourceIncludesResolver, FileSystemAccess fileSystemAccess) {
+		this.initialIncludeDirectives = initialIncludeDirectives;
+		this.sourceIncludesParser = sourceIncludesParser;
+		this.sourceIncludesResolver = sourceIncludesResolver;
+		this.fileSystemAccess = fileSystemAccess;
+		this.ignoreUnresolvedHeadersInDependencies = Boolean.getBoolean(IGNORE_UNRESOLVED_HEADERS_IN_DEPENDENCIES_PROPERTY_NAME);
+	}
+
+	public IncrementalCompileSourceProcessor files(CompilationState previousCompileState) {
+		return new DefaultIncrementalCompileSourceProcessor(previousCompileState);
+	}
+
+	private class DefaultIncrementalCompileSourceProcessor implements IncrementalCompileSourceProcessor {
+		private final CompilationState previous;
+		private final BuildableCompilationState current = new BuildableCompilationState();
+		private final List<File> toRecompile = new ArrayList<File>();
+		private final Set<File> existingHeaders = new HashSet<File>();
+		private final Map<File, FileDetails> visitedFiles = new HashMap<File, FileDetails>();
+		private boolean hasUnresolvedHeaders;
+
+		DefaultIncrementalCompileSourceProcessor(CompilationState previousCompileState) {
+			this.previous = previousCompileState == null ? new CompilationState() : previousCompileState;
+		}
+
+		@Override
+		public IncrementalCompilation getResult() {
+			return new DefaultIncrementalCompilation(current.snapshot(), toRecompile, getRemovedSources(), existingHeaders, hasUnresolvedHeaders);
+		}
+
+		@Override
+		public void processSource(File sourceFile) {
+			if (visitSourceFile(sourceFile)) {
+				toRecompile.add(sourceFile);
+			}
+		}
+
+		/**
+		 * @return true if this source file requires recompilation, false otherwise.
+		 */
+		private boolean visitSourceFile(File sourceFile) {
+			return fileSystemAccess.readRegularFileContentHash(sourceFile.getAbsolutePath())
+				.map(fileContent -> {
+					SourceFileState previousState = previous.getState(sourceFile);
+
+					if (previousState != null) {
+						// Already seen this source file before. See if we can reuse the analysis from last time
+						if (graphHasNotChanged(sourceFile, fileContent, previousState, existingHeaders)) {
+							// Include file graph for this source file has not changed, skip this file
+							current.setState(sourceFile, previousState);
+							if (previousState.isHasUnresolved() && !ignoreUnresolvedHeadersInDependencies) {
+								hasUnresolvedHeaders = true;
+								return true;
+							}
+							return false;
+						}
+						// Else, something has changed in the include file graph for this source file, so analyse again
+					}
+
+					// Source file has not been compiled before, or its include file graph has changed in some way
+					// Calculate the include file graph for the source file and mark for recompilation
+
+					CollectingMacroLookup visibleMacros = new CollectingMacroLookup(initialIncludeDirectives);
+					FileVisitResult result = visitFile(sourceFile, fileContent, visibleMacros, new HashSet<HashCode>(), existingHeaders);
+					Set<IncludeFileEdge> includedFiles = new LinkedHashSet<IncludeFileEdge>();
+					result.collectFilesInto(includedFiles, new HashSet<File>());
+					SourceFileState newState = newState(fileContent, result.result == IncludeFileResolutionResult.UnresolvedMacroIncludes, includedFiles);
+					current.setState(sourceFile, newState);
+					if (newState.isHasUnresolved()) {
+						hasUnresolvedHeaders = true;
+					}
+					return true;
+				})
+				// Skip things that aren't files
+				.orElse(false);
+		}
+
+		private boolean graphHasNotChanged(File sourceFile, HashCode fileHash, SourceFileState previousState, Set<File> existingHeaders) {
+			if (!fileHash.equals(previousState.getHash())) {
+				// Source file has changed
+				return false;
+			}
+			if (previousState.getEdges().isEmpty()) {
+				// Source file has not changed and no include files
+				return true;
+			}
+
+			// Check each unique edge in the include file graph
+			Map<HashCode, File> includes = new HashMap<HashCode, File>(previousState.getEdges().size());
+			Set<File> headers = new HashSet<File>();
+			includes.put(fileHash, sourceFile);
+			for (IncludeFileEdge includeFileEdge : previousState.getEdges()) {
+				File includedFrom = includeFileEdge.getIncludedBy() != null ? includes.get(includeFileEdge.getIncludedBy()) : null;
+				SourceIncludesResolver.IncludeFile includeFile = sourceIncludesResolver.resolveInclude(includedFrom, includeFileEdge.getIncludePath());
+				if (includeFile == null) {
+					// Include file not found (but previously was found)
+					return false;
+				}
+				HashCode hash = includeFile.getContentHash();
+				if (!hash.equals(includeFileEdge.getResolvedTo())) {
+					// Include file changed
+					return false;
+				}
+				if (!existingHeaders.contains(includeFile.getFile())) {
+					// Collect for later, do not add until the graph is known to have not changed
+					headers.add(includeFile.getFile());
+				}
+				includes.put(hash, includeFile.getFile());
+			}
+			existingHeaders.addAll(headers);
+			return true;
+		}
+
+		private FileVisitResult visitFile(File file, HashCode newHash, CollectingMacroLookup visibleMacros, Set<HashCode> visited, Set<File> existingHeaders) {
+			FileDetails fileDetails = visitedFiles.get(file);
+			if (fileDetails != null && fileDetails.results != null) {
+				// A file that we can safely reuse the result for
+				fileDetails.results.collectInto(visibleMacros);
+				return fileDetails.results;
+			}
+
+			if (!visited.add(newHash)) {
+				// A cycle, treat as resolved here
+				return new FileVisitResult(file);
+			}
+
+			if (fileDetails == null) {
+				IncludeDirectives includeDirectives = sourceIncludesParser.parseIncludes(file);
+				fileDetails = new FileDetails(includeDirectives);
+				visitedFiles.put(file, fileDetails);
+			}
+
+			CollectingMacroLookup includedFileDirectives = new CollectingMacroLookup();
+			visibleMacros.append(file, fileDetails.directives);
+
+			List<Include> allIncludes = fileDetails.directives.getAll();
+			List<FileVisitResult> included = allIncludes.isEmpty() ? Collections.<FileVisitResult>emptyList() : new ArrayList<FileVisitResult>(allIncludes.size());
+			List<IncludeFileEdge> edges = allIncludes.isEmpty() ? Collections.<IncludeFileEdge>emptyList() : new ArrayList<IncludeFileEdge>(allIncludes.size());
+			IncludeFileResolutionResult result = IncludeFileResolutionResult.NoMacroIncludes;
+			for (Include include : allIncludes) {
+				if (include.getType() == IncludeType.MACRO && result == IncludeFileResolutionResult.NoMacroIncludes) {
+					result = IncludeFileResolutionResult.HasMacroIncludes;
+				}
+				SourceIncludesResolver.IncludeResolutionResult resolutionResult = sourceIncludesResolver.resolveInclude(file, include, visibleMacros);
+				if (!resolutionResult.isComplete()) {
+					LOGGER.info("Cannot locate header file for '{}' in source file '{}'. Assuming changed.", include.getAsSourceText(), file.getName());
+					if (!ignoreUnresolvedHeadersInDependencies) {
+						result = IncludeFileResolutionResult.UnresolvedMacroIncludes;
+					}
+				}
+				for (SourceIncludesResolver.IncludeFile includeFile : resolutionResult.getFiles()) {
+					existingHeaders.add(includeFile.getFile());
+					FileVisitResult includeVisitResult = visitFile(includeFile.getFile(), includeFile.getContentHash(), visibleMacros, visited, existingHeaders);
+					if (includeVisitResult.result.ordinal() > result.ordinal()) {
+						result = includeVisitResult.result;
+					}
+					includeVisitResult.collectDependencies(includedFileDirectives);
+					included.add(includeVisitResult);
+					edges.add(new IncludeFileEdge(includeFile.getPath(), includeFile.isQuotedInclude() ? newHash : null, includeFile.getContentHash()));
+				}
+			}
+
+			FileVisitResult visitResult = new FileVisitResult(file, result, fileDetails.directives, included, edges, includedFileDirectives);
+			if (result == IncludeFileResolutionResult.NoMacroIncludes) {
+				// No macro includes were seen in the include graph of this file, so the result can be reused if this file is seen again
+				fileDetails.results = visitResult;
+			}
+			return visitResult;
+		}
+
+		private List<File> getRemovedSources() {
+			List<File> removed = new ArrayList<File>();
+			for (File previousSource : previous.getSourceInputs()) {
+				if (!current.getSourceInputs().contains(previousSource)) {
+					removed.add(previousSource);
+				}
+			}
+			return removed;
+		}
+	}
+
+	private enum IncludeFileResolutionResult {
+		NoMacroIncludes,
+		HasMacroIncludes, // but all resolved ok
+		UnresolvedMacroIncludes
+	}
+
+	/**
+	 * Details of a file that are independent of where the file appears in the file include graph.
+	 */
+	private static class FileDetails {
+		final IncludeDirectives directives;
+		// Non-null when the result of visiting this file can be reused
+		@Nullable
+		FileVisitResult results;
+
+		FileDetails(IncludeDirectives directives) {
+			this.directives = directives;
+		}
+	}
+
+	/**
+	 * Details of a file included in a specific location in the file include graph.
+	 */
+	private static class FileVisitResult /*implements CollectingMacroLookup.MacroSource*/ {
+		private final File file;
+		private final IncludeFileResolutionResult result;
+		private final IncludeDirectives includeDirectives;
+		private final List<FileVisitResult> included;
+		private final List<IncludeFileEdge> edges;
+		private final CollectingMacroLookup includeFileDirectives;
+
+		FileVisitResult(File file, IncludeFileResolutionResult result, IncludeDirectives includeDirectives, List<FileVisitResult> included, List<IncludeFileEdge> edges, CollectingMacroLookup dependentIncludeDirectives) {
+			this.file = file;
+			this.result = result;
+			this.includeDirectives = includeDirectives;
+			this.included = included;
+			this.edges = edges;
+			this.includeFileDirectives = dependentIncludeDirectives;
+		}
+
+		FileVisitResult(File file) {
+			this.file = file;
+			result = IncludeFileResolutionResult.NoMacroIncludes;
+			includeDirectives = null;
+			included = Collections.emptyList();
+			edges = Collections.emptyList();
+			includeFileDirectives = null;
+		}
+
+		void collectDependencies(CollectingMacroLookup directives) {
+			if (includeDirectives != null) {
+				collectInto(directives);
+			}
+		}
+
+		void collectFilesInto(Collection<IncludeFileEdge> files, Set<File> seen) {
+			if (includeDirectives != null && seen.add(file)) {
+				files.addAll(edges);
+				for (FileVisitResult include : included) {
+					include.collectFilesInto(files, seen);
+				}
+			}
+		}
+
+//		@Override
+		public void collectInto(CollectingMacroLookup lookup) {
+			if (includeDirectives != null) {
+				lookup.append(file, includeDirectives);
+				includeFileDirectives.appendTo(lookup);
+			}
+		}
+	}
+
+	private static SourceFileState newState(HashCode hash, boolean hasUnresolved, Set<IncludeFileEdge> resolvedIncludes) {
+		assert SourceFileState.class.getConstructors().length == 1;
+
+		try {
+			@SuppressWarnings("unchecked")
+			Constructor<SourceFileState> SourceFileState__new = (Constructor<SourceFileState>) SourceFileState.class.getConstructors()[0];
+
+			Class<?> ImmutableSet = SourceFileState__new.getParameterTypes()[SourceFileState__new.getParameterCount() - 1];
+			Method ImmutableSet__copyOf = ImmutableSet.getMethod("copyOf", Collection.class);
+			Object resolvedIncludes_asImmutableSet = ImmutableSet__copyOf.invoke(null, resolvedIncludes);
+
+			return SourceFileState__new.newInstance(hash, hasUnresolved, resolvedIncludes_asImmutableSet);
+		} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/dev/nokee/companion/features/IncrementalCompileFilesFactory.java
+++ b/src/main/java/dev/nokee/companion/features/IncrementalCompileFilesFactory.java
@@ -165,7 +165,7 @@ class IncrementalCompileFilesFactory {
 
 			if (!visited.add(newHash)) {
 				// A cycle, treat as resolved here
-				return new FileVisitResult(file);
+				return new FileVisitResult(file, fileDetails.hasMacroIncludes ? IncludeFileResolutionResult.HasMacroIncludes : IncludeFileResolutionResult.NoMacroIncludes);
 			}
 
 			if (fileDetails == null) {
@@ -184,6 +184,7 @@ class IncrementalCompileFilesFactory {
 			for (Include include : allIncludes) {
 				if (include.getType() == IncludeType.MACRO && result == IncludeFileResolutionResult.NoMacroIncludes) {
 					result = IncludeFileResolutionResult.HasMacroIncludes;
+					fileDetails.hasMacroIncludes = true;
 				}
 				SourceIncludesResolver.IncludeResolutionResult resolutionResult = sourceIncludesResolver.resolveInclude(file, include, visibleMacros);
 				if (!resolutionResult.isComplete()) {
@@ -237,6 +238,7 @@ class IncrementalCompileFilesFactory {
 		// Non-null when the result of visiting this file can be reused
 		@Nullable
 		FileVisitResult results;
+		boolean hasMacroIncludes = false;
 
 		FileDetails(IncludeDirectives directives) {
 			this.directives = directives;
@@ -263,9 +265,9 @@ class IncrementalCompileFilesFactory {
 			this.includeFileDirectives = dependentIncludeDirectives;
 		}
 
-		FileVisitResult(File file) {
+		FileVisitResult(File file, IncludeFileResolutionResult result) {
 			this.file = file;
-			result = IncludeFileResolutionResult.NoMacroIncludes;
+			this.result = result;
 			includeDirectives = null;
 			included = Collections.emptyList();
 			edges = Collections.emptyList();

--- a/src/main/java/dev/nokee/companion/features/IncrementalCompileProcessor.java
+++ b/src/main/java/dev/nokee/companion/features/IncrementalCompileProcessor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.companion.features;
+
+import org.gradle.cache.ObjectHolder;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.CallableBuildOperation;
+import org.gradle.language.nativeplatform.internal.incremental.CompilationState;
+import org.gradle.language.nativeplatform.internal.incremental.IncrementalCompilation;
+import org.gradle.language.nativeplatform.internal.incremental.IncrementalCompileSourceProcessor;
+
+import java.io.File;
+import java.util.Collection;
+
+class IncrementalCompileProcessor {
+	private final ObjectHolder<CompilationState> previousCompileStateCache;
+	private final IncrementalCompileFilesFactory incrementalCompileFilesFactory;
+	private final BuildOperationRunner buildOperationExecutor;
+
+	public IncrementalCompileProcessor(ObjectHolder<CompilationState> previousCompileStateCache, IncrementalCompileFilesFactory incrementalCompileFilesFactory, BuildOperationRunner buildOperationExecutor) {
+		this.previousCompileStateCache = previousCompileStateCache;
+		this.incrementalCompileFilesFactory = incrementalCompileFilesFactory;
+		this.buildOperationExecutor = buildOperationExecutor;
+	}
+
+	public IncrementalCompilation processSourceFiles(final Collection<File> sourceFiles) {
+		return buildOperationExecutor.call(new CallableBuildOperation<IncrementalCompilation>() {
+			@Override
+			public IncrementalCompilation call(BuildOperationContext context) {
+				CompilationState previousCompileState = previousCompileStateCache.get();
+				IncrementalCompileSourceProcessor processor = incrementalCompileFilesFactory.files(previousCompileState);
+				for (File sourceFile : sourceFiles) {
+					processor.processSource(sourceFile);
+				}
+				return processor.getResult();
+			}
+
+			@Override
+			public BuildOperationDescriptor.Builder description() {
+				ProcessSourceFilesDetails operationDetails = new ProcessSourceFilesDetails(sourceFiles.size());
+				return BuildOperationDescriptor
+					.displayName("Processing source files")
+					.details(operationDetails);
+			}
+
+			class ProcessSourceFilesDetails {
+				private final int sourceFileCount;
+
+				ProcessSourceFilesDetails(int sourceFileCount) {
+					this.sourceFileCount = sourceFileCount;
+				}
+
+				public int getSourceFileCount() {
+					return sourceFileCount;
+				}
+			}
+		});
+	}
+}

--- a/src/main/resources/META-INF/gradle-plugins/native-companion.features.fix-for-gradle-34152.properties
+++ b/src/main/resources/META-INF/gradle-plugins/native-companion.features.fix-for-gradle-34152.properties
@@ -1,0 +1,1 @@
+implementation-class=dev.nokee.companion.features.FixHeaderDiscoveryCachingFeature


### PR DESCRIPTION
This PR addresses https://github.com/gradle/gradle/issues/34152, as well as two theoretically possible issues related to it. The fixes are localized entirely in our reimplementation/inheritance of `CppCompile`. Ultimately, we will fork out entirely from the core`CppCompile` for multiple reasons. Currently, we are addressing the shortcomings. Note that using any other core native compilation tasks will also exhibit the same issue. We will release the source options and header discovery fixes as part of another PR for C compilation.